### PR TITLE
Store and find localizable routes

### DIFF
--- a/app/concerns/mcm/pages_concern.rb
+++ b/app/concerns/mcm/pages_concern.rb
@@ -1,0 +1,13 @@
+module Mcm
+  module PagesConcern
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from ActiveRecord::RecordNotFound, with: :raise_page_not_found_error
+    end
+
+    def raise_page_not_found_error
+      raise Mcm::PageNotFound
+    end
+  end
+end

--- a/app/controllers/mcm/admin/base_controller.rb
+++ b/app/controllers/mcm/admin/base_controller.rb
@@ -4,6 +4,19 @@ module Mcm
   module Admin
     class BaseController < Mcm.admin_controller_parent.constantize
       layout Mcm.admin_layout if Mcm.admin_layout.present?
+
+      around_action :switch_locale
+
+      def default_url_options
+        super.merge locale: I18n.locale
+      end
+
+      private
+
+      def switch_locale(&action)
+        locale = params[:locale] || I18n.default_locale
+        I18n.with_locale(locale, &action)
+      end
     end
   end
 end

--- a/app/controllers/mcm/admin/custom_pages_controller.rb
+++ b/app/controllers/mcm/admin/custom_pages_controller.rb
@@ -3,10 +3,16 @@
 module Mcm
   module Admin
     class CustomPagesController < BaseController
+      include Mcm::PagesConcern
+
       before_action :find_page, except: [:index, :new, :create]
 
       def index
         @custom_pages = model_class.all
+      end
+
+      def preview
+        render 'mcm/pages/show'
       end
 
       def create

--- a/app/controllers/mcm/admin/locales_controller.rb
+++ b/app/controllers/mcm/admin/locales_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Mcm
+  module Admin
+    class LocalesController < BaseController
+      include Mcm::Admin::LocalesHelper
+
+      before_action :find_locale, except: [:new, :create]
+
+      def new
+        @locale = model_class.new locale_params
+      end
+
+      def create
+        @locale = model_class.create! locale_params
+        redirect_to localizable_path
+      end
+
+      def edit
+      end
+
+      def update
+        @locale.update! locale_params
+        redirect_to localizable_path
+      end
+
+      def destroy
+        @locale.destroy
+        redirect_back fallback_location: localizable_path
+      end
+
+      private
+
+      def find_locale
+        @locale = model_class.find(params[:id])
+      end
+
+      def locale_params
+        params.require(:mcm_locale).permit :locale, :key, :value, :localizable_id, :localizable_type
+      end
+
+      def model_class
+        Mcm::Locale
+      end
+    end
+  end
+end

--- a/app/controllers/mcm/pages_controller.rb
+++ b/app/controllers/mcm/pages_controller.rb
@@ -2,25 +2,18 @@
 
 module Mcm
   class PagesController < Mcm.controller_parent.constantize
+    include Mcm::PagesConcern
+
     layout Mcm.layout if Mcm.layout.present?
 
     def show
-      @page = model_class.active.find_by!(path: request.path_info)
-    end
-
-    def preview
-      @page = model_class.find_by(path: params[:path])
-      render :show
+      @page = model_class.find_by_route(request.path_info).first!
     end
 
     private
 
     def model_class
       Mcm::Page
-    end
-
-    def page_params
-      params.require(:page)
     end
   end
 end

--- a/app/exceptions/mcm/page_not_found.rb
+++ b/app/exceptions/mcm/page_not_found.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Mcm
+  class PageNotFound < ActiveRecord::RecordNotFound
+  end
+end

--- a/app/helpers/mcm/admin/locales_helper.rb
+++ b/app/helpers/mcm/admin/locales_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mcm
+  module Admin
+    module LocalesHelper
+      def localizable_path
+        case @locale.localizable_type
+        when 'Mcm::Page'
+          main_app.admin_custom_page_path(@locale.localizable_id)
+        when 'Mcm::ComponentPage'
+          main_app.admin_component_page_path(@locale.localizable_id)
+        end
+      end
+    end
+  end
+end

--- a/app/models/mcm/locale.rb
+++ b/app/models/mcm/locale.rb
@@ -1,0 +1,16 @@
+module Mcm
+  class Locale < ApplicationRecord
+    ROUTE_REGEXP = %r{\A/[/[a-z0-9-]*]*\z}.freeze
+
+    belongs_to :localizable, polymorphic: true
+
+    validates_presence_of :locale, :key, :value, :localizable
+    validates :value, uniqueness: true, format: { with: ROUTE_REGEXP, message: I18n.t('custom_pages.pages.slug_error') }, if: :route?
+
+    scope :routes, ->{ where(key: 'route') }
+
+    def route?
+      key == 'route'
+    end
+  end
+end

--- a/app/models/mcm/page.rb
+++ b/app/models/mcm/page.rb
@@ -4,14 +4,17 @@ module Mcm
   class Page < Mcm::ApplicationRecord
     has_many :components_pages, class_name: 'Mcm::ComponentsPage', dependent: :destroy
     has_many :components, class_name: 'Mcm::Component', through: :components_pages
+    has_many :routes, ->{ routes }, class_name: 'Mcm::Locale', as: :localizable
 
     validates :name, presence: true
-    validates :path, presence: true, uniqueness: true,
-                     format: { with: %r{\A/[/[a-z0-9-]*]*\z},
-                               message: I18n.t('custom_pages.pages.slug_error') }
+
     scope :active, -> { where(active: true) }
 
     serialize :metadata, coder: Mcm::JsonSerializer
+
+    def self.find_by_route(route)
+      includes(:routes).active.where(routes: { value: route })
+    end
 
     def disabled?
       !active

--- a/app/views/mcm/admin/custom_pages/index.html.haml
+++ b/app/views/mcm/admin/custom_pages/index.html.haml
@@ -5,14 +5,17 @@
 %table.table.table-stripped
   %thead
     %th= t('custom_pages.components.name')
-    %th= t('custom_pages.path')
+    %th= t('custom_pages.routes')
     %th= t('custom_pages.is_it_live')
     %th= t('custom_pages.actions.title')
   %tboddy
     - @custom_pages.each do |page|
       %tr
         %td= link_to page.name, main_app.admin_custom_page_path(page)
-        %td= page.path
+        %td
+          %ul{style: 'list-style: none'}
+            - page.routes.each do |route|
+              %li= route.value
         %td
           = bootstrap_form_for page, as: :page, url: main_app.admin_custom_page_path(page),
               method: :put, class: "form" do |form|

--- a/app/views/mcm/admin/custom_pages/show.html.haml
+++ b/app/views/mcm/admin/custom_pages/show.html.haml
@@ -10,14 +10,32 @@
     class: 'btn btn-primary'
 
 = link_to t('custom_pages.preview'),
-  main_app.preview_page_path(path: @page.path), target: '_blank', rel: 'noopener',
+  main_app.preview_admin_custom_page_path(@page), target: '_blank', rel: 'noopener',
   class: 'btn btn-primary'
 
 = link_to t('custom_pages.actions.edit'),
   main_app.edit_admin_custom_page_path(@page),
   class: 'btn btn-primary'
 
-%h3= @page.path
+%h1= @page.name
+
+%hr
+%h4= t('custom_pages.routes')
+%table.table.table-bordered
+  %tr
+    %th= t('mcm.admin.locales.locale')
+    %th= t('mcm.admin.locales.route')
+    %th= t('custom_pages.actions.title')
+  - @page.routes.each do |route|
+    %tr
+      %td= route.locale
+      %td= route.value
+      %td
+        = link_to t('custom_pages.actions.edit'), main_app.edit_admin_locale_path(route)
+        |
+        = link_to t('custom_pages.actions.delete'), main_app.admin_locale_path(route), method: :delete, data: { confirm: t('custom_pages.messages.are_you_sure') }
+= link_to t('mcm.admin.locales.new_route'), main_app.new_admin_locale_path(mcm_locale: { key: :route, localizable_id: @page.id, localizable_type: @page.class }), class: 'btn btn-primary'
+
 
 %hr
 %h4= t('custom_pages.sections')

--- a/app/views/mcm/admin/locales/_form.html.haml
+++ b/app/views/mcm/admin/locales/_form.html.haml
@@ -1,0 +1,6 @@
+= f.text_field :locale, required: true, help: t('mcm.admin.locales.help.locale')
+= f.text_field :value, required: true, help: f.object.route? && t('mcm.admin.locales.help.route')
+= f.hidden_field :key
+= f.hidden_field :localizable_id
+= f.hidden_field :localizable_type
+= f.submit t('custom_pages.actions.save')

--- a/app/views/mcm/admin/locales/edit.html.haml
+++ b/app/views/mcm/admin/locales/edit.html.haml
@@ -1,0 +1,9 @@
+= link_to t('custom_pages.actions.back'), localizable_path, class: 'btn btn-primary'
+
+%h2= @locale.route? ? t('mcm.admin.locales.edit_route') : t('mcm.admin.locales.edit_locale')
+%h5= "Owner: #{link_to @locale.localizable.name, localizable_path}"
+
+%hr
+
+= bootstrap_form_for @locale, url: main_app.admin_locale_path(@locale), as: :mcm_locale do |form|
+  = render partial: 'form', locals: { f: form }

--- a/app/views/mcm/admin/locales/new.html.haml
+++ b/app/views/mcm/admin/locales/new.html.haml
@@ -1,0 +1,9 @@
+= link_to t('custom_pages.actions.back'), localizable_path, class: 'btn btn-primary'
+
+%h2= @locale.route? ? t('mcm.admin.locales.new_route') : t('mcm.admin.locales.new_locale')
+%h5= "Owner: #{link_to @locale.localizable.name, localizable_path}"
+
+%hr
+
+= bootstrap_form_for @locale, url: main_app.admin_locales_path, as: :mcm_locale do |form|
+  = render partial: 'form', locals: { f: form }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,8 +30,20 @@ en:
               alignment: Alignment
               color: Color
               legend: Text
+      locales:
+        edit_locale: Edit Locale
+        edit_route: Edit Route
+        help:
+          locale: "A two-character code representing the target language (examples: en, es, pt, de, ...)"
+          route: "A path for the page starting with /"
+        locale: Locale
+        route: Route
+        new_locale: New Locale
+        new_route: New Route
+        value: Value
   custom_pages:
     actions:
+      save: Save
       back: Back
       customize: Customize
       delete: Destroy
@@ -74,9 +86,9 @@ en:
         name: Internal Name
         path: 'How url will look like, it is recommended to split words with dashes: /name-of-page'
       slug_error: Slug is in the wrong format, make sure to be single word split with dashes, no spaces, lowercase, and starts with /
-    path: Path
     preview: Preview
-    sections: Section
+    routes: Routes
+    sections: Sections
     status:
       draft: Draft
       live: Live

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,8 +30,20 @@ es:
               alignment: Alineación
               color: Color
               legend: Texto
+      locales:
+        edit_locale: Editar traducción
+        edit_route: Editar ruta
+        help:
+          locale: "Código de dos caracteres del idioma de la traducción (ejemplos: en, es, pt, de, ...)"
+          route: "Una ruta para la página que empieza por /"
+        locale: Traducción
+        route: Ruta
+        new_locale: Nueva traducción
+        new_route: Nueva ruta
+        value: Valor
   custom_pages:
     actions:
+      save: Guardar
       back: Regresar
       customize: Personalizar
       delete: Borrar
@@ -76,7 +88,8 @@ es:
       slug_error: Slug especificado no cumple con el formato adecuado, debe ser sin espacios, minúsculas, palabras separadas con guiones e iniciar con /
     path: Path
     preview: Previsualizar
-    sections: Sección
+    routes: Rutas
+    sections: Secciones
     status:
       draft: Plantilla
       live: Publicada

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,16 +3,15 @@
 Rails.application.routes.draw do
   scope module: 'mcm' do
     get '*path', to: 'pages#show', constraints: ->(req) { Mcm::Page.find_by_route(req.path_info).exists? }
-    get '/preview/:path', to: 'pages#preview', as: :preview_page
 
     namespace 'admin' do
       resources :locales
       resources :custom_pages do
+        member { get :preview }
         resources :components do
           resources :components
           member { put :move_to }
         end
-        member { get :preview }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,11 @@
 
 Rails.application.routes.draw do
   scope module: 'mcm' do
-    get '*path', to: 'pages#show', constraints: ->(request) { Mcm::Page.active.find_by(path: request.path_info) }
+    get '*path', to: 'pages#show', constraints: ->(req) { Mcm::Page.find_by_route(req.path_info).exists? }
     get '/preview/:path', to: 'pages#preview', as: :preview_page
 
     namespace 'admin' do
+      resources :locales
       resources :custom_pages do
         resources :components do
           resources :components

--- a/db/migrate/20240122200047_create_mcm_assets.rb
+++ b/db/migrate/20240122200047_create_mcm_assets.rb
@@ -1,6 +1,6 @@
 class CreateMcmAssets < ActiveRecord::Migration[7.1]
   def change
-    create_table :mcm_assets do |t|
+    create_table :mcm_assets, if_not_exists: true do |t|
       t.belongs_to :components_page
       t.integer :position
       t.timestamps

--- a/db/migrate/20240130224000_create_mcm_locales.rb
+++ b/db/migrate/20240130224000_create_mcm_locales.rb
@@ -1,0 +1,10 @@
+class CreateMcmLocales < ActiveRecord::Migration[7.1]
+  def change
+    create_table :mcm_locales, if_not_exists: true do |t|
+      t.references :localizable, polymorphic: true
+      t.string :locale
+      t.string :key
+      t.string :value
+    end
+  end
+end

--- a/db/migrate/20240130233331_remove_path_from_mcm_pages.rb
+++ b/db/migrate/20240130233331_remove_path_from_mcm_pages.rb
@@ -1,0 +1,5 @@
+class RemovePathFromMcmPages < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :mcm_pages, :path
+  end
+end

--- a/spec/models/mcm/components_page_spec.rb
+++ b/spec/models/mcm/components_page_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Mcm::ComponentsPage, type: :model do
-  let!(:page) { Mcm::Page.create!(name: 'Testing page', path: '/testing-path') }
+  let!(:page) { Mcm::Page.create!(name: 'Testing page') }
 
   before :all do
     Rails.application.load_tasks

--- a/spec/requests/pages_request_spec.rb
+++ b/spec/requests/pages_request_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Pages requests", type: :request do
+  let(:page) { Mcm::Page.create! name: "Foo", active: true }
+
+  describe "localized routes" do
+    context "when a page has only one route" do
+      before do
+        page.routes.create! locale: :en, value: "/example"
+      end
+
+      it "visiting it leads to the page" do
+        get "/example"
+        expect(response).to have_http_status :ok
+
+        get "/ejemplo" # Some other route
+        expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when a page has multiple routes" do
+
+      before do
+        page.routes.create! locale: :en, value: "/example"
+        page.routes.create! locale: :es, value: "/ejemplo"
+      end
+
+      it "visiting both leads to the same page" do
+        get "/example"
+        expect(response).to have_http_status :ok
+
+        get "/ejemplo"
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ require dummy_env
 require "#{__dir__}/dummy/config/environment"
 require "rspec/rails"
 
+# Configure mcm
+Mcm.controller_parent = "ActionController::Base"
+
+# Configure rspec
 RSpec.configure do |config|
   config.order = "random"
   config.use_transactional_fixtures = true


### PR DESCRIPTION
This allows mcm to store and find localizable routes for each custom page. Routes get stored through the `Locale` model with the `:route` key. `PagesController` now looks for pages through their locales instead of their paths.

Also, `Locale` is built that way in order to allow for localizing components in a future PR.

Screenshots:

![image](https://github.com/magma-labs/mcm/assets/4645117/d8781d54-f2f3-4b56-b0c2-9a05f98da577)

![image](https://github.com/magma-labs/mcm/assets/4645117/af0c074c-b3d9-4c46-a3c4-828bc0ea921b)

![image](https://github.com/magma-labs/mcm/assets/4645117/55561f48-b256-49c2-a71c-4970a69e672a)

![image](https://github.com/magma-labs/mcm/assets/4645117/cb485b3a-cbb1-4554-8775-e7c000615933)

![image](https://github.com/magma-labs/mcm/assets/4645117/7b6d7d31-4150-40fc-ba34-e435afea18d9)

![image](https://github.com/magma-labs/mcm/assets/4645117/b89b3495-f216-4d12-92f0-705ae77be3a3)



