### PR TITLE
Improved dummy app

### DIFF
--- a/generators/dummy_app_generator.rb
+++ b/generators/dummy_app_generator.rb
@@ -1,5 +1,3 @@
-require "fileutils"
-require "rails/generators"
 require "rails/generators/rails/app/app_generator"
 
 class DummyAppGenerator < Rails::Generators::Base
@@ -21,13 +19,36 @@ class DummyAppGenerator < Rails::Generators::Base
 
   def run!
     puts "Generating dummy app..."
-    FileUtils.chdir spec_path do
+    Dir.chdir spec_path do
       Rails::Generators::AppGenerator.start([name, "--skip_bootsnap"])
     end
-    FileUtils.chdir destination_path do
+
+    Dir.chdir destination_path do
+      append_to_file "#{destination_path}/Gemfile", 'gem "mcm", path: "../.."'
+
+      insert_into_file "#{destination_path}/config/routes.rb", after: "Rails.application.routes.draw do" do
+        "\n  mount Mcm::Engine, at: '/'"
+      end
+
+      create_file "#{destination_path}/config/initializers/mcm.rb", <<~EOF
+        Mcm.controller_parent = "ApplicationController"
+        Mcm.admin_controller_parent = "ApplicationController"
+      EOF
+
       run "rake active_storage:install:migrations"
       run "rake mcm:install:migrations"
-      run "rake db:create db:migrate"
+
+      run "RAILS_ENV=test rake db:create db:migrate"
+      run "RAILS_ENV=development rake db:create db:migrate mcm:sync_components"
+
+      insert_into_file "#{destination_path}/app/views/layouts/application.html.erb", after: "<%= csp_meta_tag %>" do
+        <<~EOF
+          \n<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" />
+          <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+          <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js"></script>
+          <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"></script>
+        EOF
+      end
     end
   end
 end

--- a/lib/mcm/engine.rb
+++ b/lib/mcm/engine.rb
@@ -3,10 +3,8 @@ module Mcm
     engine_name 'mcm'
     isolate_namespace Mcm
 
-    config.assets.precompile += %w( mcm_manifest.js ) if config.respond_to?(:assets)
-
-    initializer "mcm.importmap", before: "importmap" do |app|
-      app.config.importmap.paths << Engine.root.join("config/importmap.rb") if app.config.respond_to?(:importmap)
+    initializer "mcm.assets" do |app|
+      app.config.assets.precompile += %w[mcm_manifest]
     end
   end
 end


### PR DESCRIPTION
This ensures the dummy app is ready to work as a demo app if needed.
Just run the following to get it up and running:

- `rake dummy:setup`
- `rails server`
